### PR TITLE
Track also CPU time (user and system)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var tourism = require('tourism');
+const tourism = require('tourism');
 
 module.exports = tourism({
   analyse: {
     server: [ '**/*.js', '!node_modules/**/*.js', '!coverage/**/*.js' ],
     options: {
       server: {
-        language: 'es5'
+        language: 'es6'
       }
     }
   },

--- a/circle.yml
+++ b/circle.yml
@@ -2,12 +2,12 @@ machine:
   timezone: Europe/Berlin
 
   node:
-    version: 4.0.0
+    version: 6.3.1
 
 dependencies:
   pre:
-    - npm install -g grunt-cli
+    - npm install -g roboter-cli
 
 test:
   override:
-    - grunt
+    - bot build-server

--- a/lib/Stethoskop.js
+++ b/lib/Stethoskop.js
@@ -9,8 +9,13 @@ const fakeStethoskop = {
   noteValue () {}
 };
 
-const intervalInSeconds = 60;
-let lastCpuUsage;
+let lastCpuCheck,
+    lastCpuUsage;
+
+const resetCpuCheck = function () {
+  lastCpuCheck = process.hrtime();
+  lastCpuUsage = process.cpuUsage();
+};
 
 const Stethoskop = function (options) {
   if (!options.enabled) {
@@ -23,24 +28,29 @@ const Stethoskop = function (options) {
     prefix: util.format('%s.%s.', options.from.application, os.hostname())
   });
 
-  this.watchSystemUsage();
+  resetCpuCheck();
+
+  this.watchSystemUsage(60);
 };
 
-Stethoskop.prototype.watchSystemUsage = function () {
+Stethoskop.prototype.watchSystemUsage = function (seconds) {
   setInterval(() => {
     this.noteCpuUsage();
     this.noteMemoryUsage();
-  }, intervalInSeconds * 1000);
+  }, seconds * 1000);
 };
 
 Stethoskop.prototype.noteCpuUsage = function () {
   const averageLoad = os.loadavg()[0],
-        cpuUsage = process.cpuUsage(lastCpuUsage);
+        cpuUsage = process.cpuUsage(lastCpuUsage),
+        interval = process.hrtime(lastCpuCheck) / 1000;
 
+  resetCpuCheck();
+
+  this.noteValue('$cpu.checkInterval', interval);
   this.noteValue('$cpu.load.average', averageLoad / os.cpus().length);
-  this.noteValue('$cpu.usage.system', cpuUsage.system / (intervalInSeconds * 1000 * 1000));
-  this.noteValue('$cpu.usage.user', cpuUsage.user / (intervalInSeconds * 1000 * 1000));
-  lastCpuUsage = cpuUsage;
+  this.noteValue('$cpu.usage.system', cpuUsage.system / interval);
+  this.noteValue('$cpu.usage.user', cpuUsage.user / interval);
 };
 
 Stethoskop.prototype.noteMemoryUsage = function () {

--- a/lib/Stethoskop.js
+++ b/lib/Stethoskop.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var os = require('os'),
-    util = require('util');
+const os = require('os'),
+      util = require('util');
 
-var StatsD = require('node-statsd');
+const StatsD = require('node-statsd');
 
-var fakeStethoskop = {
-  noteValue: function () {}
+const fakeStethoskop = {
+  noteValue () {}
 };
 
-var Stethoskop = function (options) {
+const Stethoskop = function (options) {
   if (!options.enabled) {
     return fakeStethoskop;
   }
@@ -24,23 +24,21 @@ var Stethoskop = function (options) {
 };
 
 Stethoskop.prototype.watchSystemUsage = function (seconds) {
-  var that = this;
-
-  setInterval(function () {
-    that.noteCpuUsage();
-    that.noteMemoryUsage();
+  setInterval(() => {
+    this.noteCpuUsage();
+    this.noteMemoryUsage();
   }, seconds * 1000);
 };
 
 Stethoskop.prototype.noteCpuUsage = function () {
-  var averageLoad = os.loadavg()[0],
-      numberOfCpus = os.cpus().length;
+  const averageLoad = os.loadavg()[0],
+        numberOfCpus = os.cpus().length;
 
   this.noteValue('$cpu.load.average', averageLoad / numberOfCpus);
 };
 
 Stethoskop.prototype.noteMemoryUsage = function () {
-  var memoryUsage = process.memoryUsage();
+  const memoryUsage = process.memoryUsage();
 
   this.noteValue('$memory.rss', memoryUsage.rss);
   this.noteValue('$memory.heap.used', memoryUsage.heapUsed);

--- a/lib/Stethoskop.js
+++ b/lib/Stethoskop.js
@@ -9,6 +9,9 @@ const fakeStethoskop = {
   noteValue () {}
 };
 
+const intervalInSeconds = 60;
+let lastCpuUsage;
+
 const Stethoskop = function (options) {
   if (!options.enabled) {
     return fakeStethoskop;
@@ -20,21 +23,24 @@ const Stethoskop = function (options) {
     prefix: util.format('%s.%s.', options.from.application, os.hostname())
   });
 
-  this.watchSystemUsage(60);
+  this.watchSystemUsage();
 };
 
-Stethoskop.prototype.watchSystemUsage = function (seconds) {
+Stethoskop.prototype.watchSystemUsage = function () {
   setInterval(() => {
     this.noteCpuUsage();
     this.noteMemoryUsage();
-  }, seconds * 1000);
+  }, intervalInSeconds * 1000);
 };
 
 Stethoskop.prototype.noteCpuUsage = function () {
   const averageLoad = os.loadavg()[0],
-        numberOfCpus = os.cpus().length;
+        cpuUsage = process.cpuUsage(lastCpuUsage);
 
-  this.noteValue('$cpu.load.average', averageLoad / numberOfCpus);
+  this.noteValue('$cpu.load.average', averageLoad / os.cpus().length);
+  this.noteValue('$cpu.usage.system', cpuUsage.system / (intervalInSeconds * 1000 * 1000));
+  this.noteValue('$cpu.usage.user', cpuUsage.user / (intervalInSeconds * 1000 * 1000));
+  lastCpuUsage = cpuUsage;
 };
 
 Stethoskop.prototype.noteMemoryUsage = function () {

--- a/lib/Stethoskop.js
+++ b/lib/Stethoskop.js
@@ -17,6 +17,10 @@ const resetCpuCheck = function () {
   lastCpuUsage = process.cpuUsage();
 };
 
+const getMicroseconds = function (hrTime) {
+  return hrTime[0] * 1e9 + hrTime[1];
+};
+
 const Stethoskop = function (options) {
   if (!options.enabled) {
     return fakeStethoskop;
@@ -43,7 +47,7 @@ Stethoskop.prototype.watchSystemUsage = function (seconds) {
 Stethoskop.prototype.noteCpuUsage = function () {
   const averageLoad = os.loadavg()[0],
         cpuUsage = process.cpuUsage(lastCpuUsage),
-        interval = process.hrtime(lastCpuCheck) / 1000;
+        interval = getMicroseconds(process.hrtime(lastCpuCheck)) / 1000;
 
   resetCpuCheck();
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "assertthat": "0.8.0",
     "gulp": "3.9.1",
-    "roboter": "0.12.2"
+    "roboter": "0.11.12"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "node-statsd": "0.1.1"
   },
   "devDependencies": {
-    "assertthat": "0.6.0",
-    "grunt": "0.4.5",
-    "tourism": "0.16.1"
+    "assertthat": "0.8.0",
+    "gulp": "3.9.1",
+    "roboter": "0.12.2"
   },
   "repository": {
     "type": "git",

--- a/roboter.js
+++ b/roboter.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const roboter = require('roboter');
+
+roboter.
+  workOn('server').
+  equipWith(task => {
+    task('universal/analyze', {
+      src: [ '**/*.js', '!node_modules/**/*.js', '!coverage/**/*.js' ]
+    });
+
+    task('universal/test-units', {
+      src: 'test/**/*Tests.js'
+    });
+
+    task('universal/coverage', {
+      src: 'lib/**/*.js',
+      test: 'test/**/*Tests.js'
+    });
+  }).
+  start();

--- a/test/StethoskopTests.js
+++ b/test/StethoskopTests.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var assert = require('assertthat');
+const assert = require('assertthat');
 
-var Stethoskop = require('../lib/Stethoskop.js');
+const Stethoskop = require('../lib/Stethoskop.js');
 
-suite('Stethoskop', function () {
-  test('is a function.', function (done) {
+suite('Stethoskop', () => {
+  test('is a function.', done => {
     assert.that(Stethoskop).is.ofType('function');
     done();
   });


### PR DESCRIPTION
Currently, Stethoskop tracks the load of the system the application is running on. Unfortunately, this is not possible for Windows. So, I've extended the Stethoskop to also track the CPU time used by the process. It is provided as the fraction of the total time since the last check (60 seconds).

Now, you can create a graph of the (stacked) user and system time:

<img width="653" alt="screenshot 2016-08-04 08 42 15" src="https://cloud.githubusercontent.com/assets/3170455/17392991/1b7ee75c-5a21-11e6-91c0-9443759423a1.png">